### PR TITLE
[trickle] trickle server/channel

### DIFF
--- a/economytrickle/economytrickle.py
+++ b/economytrickle/economytrickle.py
@@ -120,7 +120,7 @@ class Economytrickle:
         fmt = ''
         if settings['TOGGLE'] is not True:
             fmt = ('Note: You will not see these changes take effect until you set '
-                       '`{}trickleset server` to **channels**.\n'.format(ctx.prefix))
+                       '`{}trickleset toggle` to **channels**.\n'.format(ctx.prefix))
 
         csets = settings['CHANNELS']
         current = sorted(filter(None, (server.get_channel(c) for c in csets)),

--- a/economytrickle/economytrickle.py
+++ b/economytrickle/economytrickle.py
@@ -101,9 +101,9 @@ class Economytrickle:
                                                       channel=channel)
                 if msg is None:
                     msgs[True] = 'No Response. ' + msgs[True]
-                    setting['TOGGLE'] = True
+                    settings['TOGGLE'] = True
                 elif 'serv' not in msg.content.lower():
-                    setting['TOGGLE'] = True
+                    settings['TOGGLE'] = True
 
         await self.bot.say(msgs[settings['TOGGLE']].format(ctx.prefix))
         dataIO.save_json("data/economytrickle/settings.json", self.settings)

--- a/economytrickle/economytrickle.py
+++ b/economytrickle/economytrickle.py
@@ -28,7 +28,7 @@ class Economytrickle:
         self.defaultSettings = {"TRICKLE_BOT" : False, "NEW_ACTIVE_BONUS" : 1, 
                                 "ACTIVE_BONUS_DEFLATE" : 1, "PAYOUT_INTERVAL" : 2, 
                                 "CHANCE_TO_PAYOUT" : 50, "PAYOUT_PER_ACTIVE" : 1, 
-                                "ACTIVE_TIMEOUT" : 10, "TOGGLE": False, "CHANNELS" = []}
+                                "ACTIVE_TIMEOUT" : 10, "TOGGLE": False, "CHANNELS" : []}
 
     @commands.group(pass_context=True, no_pm=True)
     @checks.mod_or_permissions(manage_server=True)

--- a/economytrickle/economytrickle.py
+++ b/economytrickle/economytrickle.py
@@ -72,7 +72,7 @@ class Economytrickle:
         author = ctx.message.author
 
         settings = self.settings[server.id]
-        context = context.lower()
+        context = context.lower() if context else context
 
         toggled = not settings['TOGGLE']
         choices = {'channels': True, 'server': 'SERVER', 


### PR DESCRIPTION
please test and comment

added
[p]trickleset toggle - toggles trickle for server/channel list
[p]trickleset channel - manage channels in trickle channel list

tested:

- [ ] 1. `[p]trickleset` displays channels and yes/no for boolean settings
- [ ] 2. `[p]trickleset toggle` - toggles trickle for server/channel list
    - [ ] 2.1 defaults to toggling 
        - [ ] 2.1.1 if toggle on and no channels set, interactive prompt
    - [ ] 2.2 toggling it off stops trickling for the server
    - [ ] 2.3 toggling to server trickles to every channel
    - [ ] 2.4 toggling to channel trickles to channels set with `[p]trickleset channel`
- [ ] 3. `[p]trickleset channel` - lists and manages channel list to trickle to
    - [ ] 3.1 left blank, lists the channels set to trickle to (msg if empty)
    - [ ] 3.2 using with multiple channels in one call works the same as if only 1 was used
    - [ ] 3.3 using channels already in the list will remove them
    - [ ] 3.4 using channels not in the list will add them
    - [ ] 3.6 using channels that have only some members in the list will start interactive prompt
        - [ ] 3.6.1 cancel doesn't change the list
        - [ ] 3.6.2 other choices correctly do 3.3/3.4
